### PR TITLE
Fix #349

### DIFF
--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/AnnotatingElementExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/AnnotatingElementExtensions.cs
@@ -78,14 +78,15 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/AssociationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/AssociationExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/DependencyExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/DependencyExtensions.cs
@@ -70,11 +70,12 @@ namespace SysML2.NET.Dal
 
             poco.AliasIds = dto.AliasIds;
 
-            var clientToDelete = poco.Client.Select(x => x.Id).Except(dto.Client);
+            var clientRetained = new HashSet<Guid>(dto.Client);
+            var clientToDelete = poco.Client.Where(x => !clientRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in clientToDelete)
+            foreach (var client in clientToDelete)
             {
-                poco.Client.Remove(poco.Client.Single(x => x.Id == identifier));
+                poco.Client.Remove(client);
             }
 
 
@@ -88,29 +89,32 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
-            var supplierToDelete = poco.Supplier.Select(x => x.Id).Except(dto.Supplier);
+            var supplierRetained = new HashSet<Guid>(dto.Supplier);
+            var supplierToDelete = poco.Supplier.Where(x => !supplierRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in supplierToDelete)
+            foreach (var supplier in supplierToDelete)
             {
-                poco.Supplier.Remove(poco.Supplier.Single(x => x.Id == identifier));
+                poco.Supplier.Remove(supplier);
             }
 
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/EnumerationDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FlowExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FlowExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/FramedConcernMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/LiteralIntegerExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/LiteralIntegerExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/LiteralRationalExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/LiteralRationalExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/MembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/MembershipExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.MemberShortName = dto.MemberShortName;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/MultiplicityRangeExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/OwningMembershipExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/OwningMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/RequirementUsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/RequirementUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SelectExpressionExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SelectExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/TextualRepresentationExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/TextualRepresentationExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.Language = dto.Language;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/UsageExtensions.cs
+++ b/SysML2.NET.CodeGenerator.Tests/Expected/UML/Core/AutoGenPocoExtension/UsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.CodeGenerator/Templates/Uml/core-dal-poco-uml-extensions.hbs
+++ b/SysML2.NET.CodeGenerator/Templates/Uml/core-dal-poco-uml-extensions.hbs
@@ -75,19 +75,20 @@ namespace SysML2.NET.Dal
                 {{#unless (Property.IsPropertyRedefinedInClass this class)}}
                 {{#if (Property.QueryIsReferenceProperty property)}}
                     {{#if (Property.QueryIsEnumerable property) }}
-                            var {{ property.Name}}ToDelete = poco.{{ String.PascalCase property.Name}}.Select(x => x.Id).Except(dto.{{ String.PascalCase property.Name}});
-                    
-                            foreach (var identifier in {{ property.Name}}ToDelete)
+                            var {{ property.Name}}Retained = new HashSet<Guid>(dto.{{ String.PascalCase property.Name}});
+                            var {{ property.Name}}ToDelete = poco.{{ String.PascalCase property.Name}}.Where(x => !{{ property.Name}}Retained.Contains(x.Id)).ToList();
+
+                            foreach (var {{ property.Name}} in {{ property.Name}}ToDelete)
                             {
                         {{#if property.IsComposite }}
-                            ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Remove(poco.{{ String.PascalCase property.Name}}.Single(x => x.Id == identifier));
+                            ((IContained{{property.Owner.Name}})poco).{{ String.PascalCase property.Name}}.Remove({{ property.Name}});
                         {{else}}
-                            poco.{{ String.PascalCase property.Name}}.Remove(poco.{{ String.PascalCase property.Name}}.Single(x => x.Id == identifier));
+                            poco.{{ String.PascalCase property.Name}}.Remove({{ property.Name}});
                         {{/if}}
                             }
-                    
+
                         {{#if property.IsComposite }}
-                            identifiersOfObjectsToDelete.AddRange({{ property.Name}}ToDelete);
+                            identifiersOfObjectsToDelete.AddRange({{ property.Name}}ToDelete.Select(x => x.Id));
                         {{/if}}
 
                     {{/if}}

--- a/SysML2.NET.Dal.Tests/AssemblerTestFixture.cs
+++ b/SysML2.NET.Dal.Tests/AssemblerTestFixture.cs
@@ -168,6 +168,64 @@ namespace SysML2.NET.Dal.Tests
         }
 
         [Test]
+        public void Synchronize_WithRemovedOwnedRelationship_RemovesThePocoFromTheCache()
+        {
+            var ownerId = Guid.Parse("1b7c1f14-9a2e-4c8d-8f3b-2c6e0d5a4b91");
+            var membershipId = Guid.Parse("2c8d2f25-8b3f-4d9e-9a4c-3d7f1e6b5c02");
+            var packageId = Guid.Parse("3d9e3f36-7c4a-4eaf-8b5d-4e802f7c6d13");
+
+            var ownerDto = new Core.DTO.Kernel.Packages.Package
+            {
+                Id = ownerId,
+                DeclaredName = "the owner",
+                ElementId = ownerId.ToString(),
+                OwnedRelationship = [membershipId]
+            };
+
+            var membershipDto = new Core.DTO.Root.Namespaces.OwningMembership
+            {
+                Id = membershipId,
+                OwnedRelatedElement = [packageId],
+                OwningRelatedElement = ownerId
+            };
+
+            var packageDto = new Core.DTO.Kernel.Packages.Package
+            {
+                Id = packageId,
+                DeclaredName = "the owned package",
+                ElementId = packageId.ToString(),
+                OwningRelationship = membershipId
+            };
+
+            this.assembler.Synchronize([ownerDto, membershipDto, packageDto]);
+
+            Core.POCO.Kernel.Packages.Package ownerPoco = null;
+
+            if (this.assembler.Cache.TryGetValue(ownerId, out this.lazyPoco))
+            {
+                ownerPoco = (Core.POCO.Kernel.Packages.Package)this.lazyPoco.Value;
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(this.assembler.Cache, Has.Count.EqualTo(3));
+                Assert.That(ownerPoco.OwnedRelationship, Has.Count.EqualTo(1));
+            }
+
+            // drop the membership from the owner and from the delta, which is what a server-side removal looks like
+            ownerDto.OwnedRelationship = [];
+
+            Assert.That(() => this.assembler.Synchronize([ownerDto, packageDto]), Throws.Nothing);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ownerPoco.OwnedRelationship, Has.Count.EqualTo(0));
+                Assert.That(this.assembler.Cache.ContainsKey(membershipId), Is.False);
+                Assert.That(this.assembler.Cache, Has.Count.EqualTo(2));
+            }
+        }
+
+        [Test]
         public void Synchronize_WithGrowingDtoSequence_DoesNotRescanTheSequencePerElement()
         {
             var smallModel = new EnumerationCountingElements(64);

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AcceptActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AcceptActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActionDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActionDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActorMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ActorMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AllocationDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AllocationDefinitionExtensions.cs
@@ -88,23 +88,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AllocationUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AllocationUsageExtensions.cs
@@ -104,23 +104,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnalysisCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnalysisCaseDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnalysisCaseUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnalysisCaseUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnnotatingElementExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnnotatingElementExtensions.cs
@@ -78,14 +78,15 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnnotationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AnnotationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssertConstraintUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssertConstraintUsageExtensions.cs
@@ -104,14 +104,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssignmentActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssignmentActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssociationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssociationExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssociationStructureExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AssociationStructureExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AttributeDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AttributeDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/AttributeUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/AttributeUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/BehaviorExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/BehaviorExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/BindingConnectorAsUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/BindingConnectorAsUsageExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/BindingConnectorExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/BindingConnectorExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/BooleanExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/BooleanExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CalculationDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CalculationDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CalculationUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CalculationUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CaseDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CaseDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CaseUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CaseUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ClassExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ClassExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ClassifierExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ClassifierExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CollectExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CollectExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CommentExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CommentExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.Locale = dto.Locale;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConcernDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConcernDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.ReqId = dto.ReqId;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConcernUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConcernUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortTypingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugatedPortTypingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConjugationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectionDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectionDefinitionExtensions.cs
@@ -88,23 +88,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectionUsageExtensions.cs
@@ -104,23 +104,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectorExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConnectorExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstraintDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstraintDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstraintUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstraintUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstructorExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ConstructorExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/CrossSubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/CrossSubsettingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DataTypeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DataTypeExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DecisionNodeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DecisionNodeExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DependencyExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DependencyExtensions.cs
@@ -70,11 +70,12 @@ namespace SysML2.NET.Dal
 
             poco.AliasIds = dto.AliasIds;
 
-            var clientToDelete = poco.Client.Select(x => x.Id).Except(dto.Client);
+            var clientRetained = new HashSet<Guid>(dto.Client);
+            var clientToDelete = poco.Client.Where(x => !clientRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in clientToDelete)
+            foreach (var client in clientToDelete)
             {
-                poco.Client.Remove(poco.Client.Single(x => x.Id == identifier));
+                poco.Client.Remove(client);
             }
 
 
@@ -88,29 +89,32 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
-            var supplierToDelete = poco.Supplier.Select(x => x.Id).Except(dto.Supplier);
+            var supplierRetained = new HashSet<Guid>(dto.Supplier);
+            var supplierToDelete = poco.Supplier.Where(x => !supplierRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in supplierToDelete)
+            foreach (var supplier in supplierToDelete)
             {
-                poco.Supplier.Remove(poco.Supplier.Single(x => x.Id == identifier));
+                poco.Supplier.Remove(supplier);
             }
 
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DifferencingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DifferencingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DisjoiningExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DisjoiningExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/DocumentationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/DocumentationExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.Locale = dto.Locale;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ElementFilterMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ElementFilterMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/EndFeatureMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/EndFeatureMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/EnumerationDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/EnumerationDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/EnumerationUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/EnumerationUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/EventOccurrenceUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/EventOccurrenceUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ExhibitStateUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ExhibitStateUsageExtensions.cs
@@ -104,14 +104,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureChainingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureInvertingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureInvertingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureReferenceExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureReferenceExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureTypingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureValueExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FeatureValueExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsInitial = dto.IsInitial;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowDefinitionExtensions.cs
@@ -88,23 +88,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowEndExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowEndExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FlowUsageExtensions.cs
@@ -104,23 +104,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ForLoopActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ForLoopActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ForkNodeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ForkNodeExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FramedConcernMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FramedConcernMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/FunctionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/FunctionExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/IfActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/IfActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/IncludeUseCaseUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/IncludeUseCaseUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/IndexExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/IndexExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/InteractionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/InteractionExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/InterfaceDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/InterfaceDefinitionExtensions.cs
@@ -88,23 +88,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/InterfaceUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/InterfaceUsageExtensions.cs
@@ -104,23 +104,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/IntersectingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/IntersectingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/InvariantExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/InvariantExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/InvocationExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/InvocationExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ItemDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ItemDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ItemUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ItemUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/JoinNodeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/JoinNodeExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LibraryPackageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LibraryPackageExtensions.cs
@@ -80,14 +80,15 @@ namespace SysML2.NET.Dal
 
             poco.IsStandard = dto.IsStandard;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralBooleanExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralBooleanExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralInfinityExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralInfinityExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralIntegerExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralIntegerExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralRationalExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralRationalExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralStringExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/LiteralStringExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Value = dto.Value;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExposeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExposeExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsRecursive = dto.IsRecursive;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.MemberShortName = dto.MemberShortName;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipImportExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MembershipImportExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsRecursive = dto.IsRecursive;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MergeNodeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MergeNodeExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetaclassExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetaclassExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataAccessExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataAccessExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataFeatureExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataFeatureExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MetadataUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MultiplicityExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MultiplicityExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/MultiplicityRangeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/MultiplicityRangeExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExposeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExposeExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsRecursive = dto.IsRecursive;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceExtensions.cs
@@ -78,14 +78,15 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceImportExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NamespaceImportExtensions.cs
@@ -84,23 +84,25 @@ namespace SysML2.NET.Dal
 
             poco.IsRecursive = dto.IsRecursive;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/NullExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/NullExpressionExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ObjectiveMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ObjectiveMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/OccurrenceDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/OccurrenceDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/OccurrenceUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/OccurrenceUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/OperatorExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/OperatorExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/OwningMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/OwningMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PackageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PackageExtensions.cs
@@ -78,14 +78,15 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ParameterMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ParameterMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PartDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PartDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PartUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PartUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PayloadFeatureExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PayloadFeatureExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PerformActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PerformActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortConjugationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortConjugationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PortUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/PredicateExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/PredicateExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RedefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RedefinitionExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceSubsettingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReferenceUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RenderingDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RenderingDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RenderingUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RenderingUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementConstraintMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementConstraintMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.ReqId = dto.ReqId;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementVerificationMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/RequirementVerificationMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ResultExpressionMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ResultExpressionMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReturnParameterMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ReturnParameterMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SatisfyRequirementUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SatisfyRequirementUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SelectExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SelectExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Operator = dto.Operator;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SendActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SendActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SpecializationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SpecializationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StakeholderMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StakeholderMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateDefinitionExtensions.cs
@@ -88,14 +88,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateSubactionMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateSubactionMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StateUsageExtensions.cs
@@ -104,14 +104,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StepExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StepExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/StructureExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/StructureExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubclassificationExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubjectMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubjectMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubsettingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SubsettingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionAsUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionAsUsageExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionFlowExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionFlowExtensions.cs
@@ -102,23 +102,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariable = dto.IsVariable;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionFlowUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/SuccessionFlowUsageExtensions.cs
@@ -104,23 +104,25 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TerminateActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TerminateActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TextualRepresentationExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TextualRepresentationExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.Language = dto.Language;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TransitionFeatureMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TransitionFeatureMembershipExtensions.cs
@@ -82,23 +82,25 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TransitionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TransitionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TriggerInvocationExpressionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TriggerInvocationExpressionExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.Kind = dto.Kind;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeExtensions.cs
@@ -82,14 +82,15 @@ namespace SysML2.NET.Dal
 
             poco.IsSufficient = dto.IsSufficient;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeFeaturingExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/TypeFeaturingExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/UnioningExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/UnioningExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/UsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/UsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/UseCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/UseCaseDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/UseCaseUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/UseCaseUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/VariantMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/VariantMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/VerificationCaseDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/VerificationCaseDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/VerificationCaseUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/VerificationCaseUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewDefinitionExtensions.cs
@@ -86,14 +86,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
 
             return identifiersOfObjectsToDelete;

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewRenderingMembershipExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewRenderingMembershipExtensions.cs
@@ -80,23 +80,25 @@ namespace SysML2.NET.Dal
 
             poco.IsImpliedIncluded = dto.IsImpliedIncluded;
 
-            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Select(x => x.Id).Except(dto.OwnedRelatedElement);
+            var ownedRelatedElementRetained = new HashSet<Guid>(dto.OwnedRelatedElement);
+            var ownedRelatedElementToDelete = poco.OwnedRelatedElement.Where(x => !ownedRelatedElementRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelatedElementToDelete)
+            foreach (var ownedRelatedElement in ownedRelatedElementToDelete)
             {
-                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(poco.OwnedRelatedElement.Single(x => x.Id == identifier));
+                ((IContainedRelationship)poco).OwnedRelatedElement.Remove(ownedRelatedElement);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelatedElementToDelete.Select(x => x.Id));
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.Visibility = dto.Visibility;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewpointDefinitionExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewpointDefinitionExtensions.cs
@@ -84,14 +84,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.ReqId = dto.ReqId;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewpointUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/ViewpointUsageExtensions.cs
@@ -100,14 +100,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 

--- a/SysML2.NET.Dal/Core/AutoGenPocoExtension/WhileLoopActionUsageExtensions.cs
+++ b/SysML2.NET.Dal/Core/AutoGenPocoExtension/WhileLoopActionUsageExtensions.cs
@@ -102,14 +102,15 @@ namespace SysML2.NET.Dal
 
             poco.IsVariation = dto.IsVariation;
 
-            var ownedRelationshipToDelete = poco.OwnedRelationship.Select(x => x.Id).Except(dto.OwnedRelationship);
+            var ownedRelationshipRetained = new HashSet<Guid>(dto.OwnedRelationship);
+            var ownedRelationshipToDelete = poco.OwnedRelationship.Where(x => !ownedRelationshipRetained.Contains(x.Id)).ToList();
 
-            foreach (var identifier in ownedRelationshipToDelete)
+            foreach (var ownedRelationship in ownedRelationshipToDelete)
             {
-                ((IContainedElement)poco).OwnedRelationship.Remove(poco.OwnedRelationship.Single(x => x.Id == identifier));
+                ((IContainedElement)poco).OwnedRelationship.Remove(ownedRelationship);
             }
 
-            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete);
+            identifiersOfObjectsToDelete.AddRange(ownedRelationshipToDelete.Select(x => x.Id));
 
             poco.PortionKind = dto.PortionKind;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/SysML2.NET/pulls) open
- [x] I have verified that I am following the SysML2.NET [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/SysML2.NET/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #349 

No more InvalidOperationExcpetion thrown while removing elements from the collection and improved test coverage on the assembler re-synchronization
<!-- Thanks for contributing to SysML2.NET! -->